### PR TITLE
Fix root route handler

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -167,7 +167,7 @@ async function main() {
     }
   }
 
-  fastify.get('/', async () => await { status: '🚀 Server is running' });
+  fastify.get('/', async () => ({ status: '🚀 Server is running' }));
 
   await fastify.listen({ port: 3000, host: '0.0.0.0' });
   // eslint-disable-next-line no-console


### PR DESCRIPTION
## Summary
- fix return value for root healthcheck route

## Testing
- `yarn workspace server test` *(fails: fetch blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6840023ed3248327ab362df8e27a2959